### PR TITLE
Added support for Puppet

### DIFF
--- a/src/main/kotlin/com/kevinlinxp/sublimeSnippetsSupport/SublimeSnippetScope.kt
+++ b/src/main/kotlin/com/kevinlinxp/sublimeSnippetsSupport/SublimeSnippetScope.kt
@@ -29,6 +29,7 @@ enum class SublimeSnippetScope(private val scopeName: String, private val contex
     SOURCE_TS("source.ts", "TypeScript"),
     SOURCE_TSX("source.tsx", "TypeScript"),
     SOURCE_LUA("source.lua", "LUA"),
+    SOURCE_PUPPET("source.puppet", "PUPPET_FILE"),
     TEXT_HTML("text.html", "HTML_TEXT"),
     TEXT_HTML_BASIC("text.html.basic", "HTML_TEXT"),
     TEXT_HTML_JAVADOC("text.html.javadoc", "HTML_TEXT"),


### PR DESCRIPTION
I added Puppet to the scope.

Honestly, I have no idea if this is enough - but I was able to build the Plugin locally and use it.

To build it locally, I needed to Change the `kotlin_version `as well. 
https://github.com/kevinlinxp/intellij-sublime-snippets-support/blob/master/build.gradle#L2
````
    ext.kotlin_version = '1.3.72'
````

In any case, thank you for this plugin! It looks like it's the best way to manage live templates.